### PR TITLE
Style Changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no" />
@@ -8,10 +9,13 @@
   <!-- ArcGIS & Fonts -->
   <link rel="stylesheet" href="https://js.arcgis.com/4.26/esri/themes/light/main.css" />
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="widget-styles.css">
   <script src="https://js.arcgis.com/4.26/"></script>
 
   <style>
-    html, body, #viewDiv {
+    html,
+    body,
+    #viewDiv {
       padding: 0;
       margin: 0;
       height: 100%;
@@ -49,7 +53,8 @@
       color: #00ff40;
     }
 
-    .esri-popup__content, .esri-popup__header-title {
+    .esri-popup__content,
+    .esri-popup__header-title {
       font-family: 'Orbitron', sans-serif;
       color: #00ff40;
     }
@@ -59,10 +64,21 @@
 <body>
   <!-- Report button linking to Survey123 form -->
   <a href="https://arcg.is/1qjujz1" target="_blank" class="reportBtn">Report a Sighting</a>
+
+  <!-- Vertical pill to hold control widgets -->
+  <div id="controls">
+    <div id="infoControl"></div>
+    <div id="zoomControl"></div>
+    <div id="locateControl"></div>
+    <div id="legendControl"></div>
+    <div id="basemapControl"></div>
+  </div>
+  <!-- Map -->
   <div id="viewDiv"></div>
 
   <script>
     require([
+      "esri/widgets/Zoom",
       "esri/config",
       "esri/Map",
       "esri/views/MapView",
@@ -73,7 +89,7 @@
       "esri/widgets/Expand",
       "esri/widgets/BasemapGallery"
     ], (
-      esriConfig, Map, MapView, FeatureLayer,
+      Zoom, esriConfig, Map, MapView, FeatureLayer,
       Locate, Search, Legend, Expand, BasemapGallery
     ) => {
 
@@ -87,21 +103,20 @@
         container: "viewDiv",
         map: map,
         center: [-98, 39],
-        zoom: 4
+        zoom: 4,
+        ui: {
+          components: [] // <-- this keeps ALL widgets from the view, add these manually in divs for some control over placement and styling
+        }
       });
 
-      // Locate and Search widgets
-      view.ui.add(new Locate({ view }), "top-left");
-      view.ui.add(new Search({ view }), "bottom-right");
-
-      // Custom renderer using your UFO icon
+      // can be clustered client side if the points start colliding
       const uapRenderer = {
         type: "simple",
         symbol: {
           type: "picture-marker",
           url: "https://raw.githubusercontent.com/DavidKimmel/uap_reporting/main/ufoicon.png",
-          width: "32px",
-          height: "32px"
+          width: "42px",
+          height: "42px"
         },
         label: "UAP encounter"
       };
@@ -113,10 +128,10 @@
           {
             type: "fields",
             fieldInfos: [
-              { fieldName: "time_of_incident", label: "Time of Incident", format: { dateFormat: "short-date-short-time" }},
+              { fieldName: "time_of_incident", label: "Time of Incident", format: { dateFormat: "short-date-short-time" } },
               { fieldName: "describe_encounter", label: "Description" },
               { fieldName: "Creator", label: "Submitted By" },
-              { fieldName: "CreationDate", label: "Submitted On", format: { dateFormat: "short-date-short-time" }}
+              { fieldName: "CreationDate", label: "Submitted On", format: { dateFormat: "short-date-short-time" } }
             ]
           },
           {
@@ -133,40 +148,100 @@
         popupTemplate: popupTemplate
       });
 
-      map.add(uapLayer);
+      const haloRenderer = {
+        type: "simple",
+        symbol: {
+          type: "simple-marker",
+          style: "circle",
+          size: "38px",
+          color: [0, 255, 64, 0.1],
+          outline: {
+            color: [0, 255, 64, 0.15],
+            width: "2px"
+          }
+        }
+      };
 
-      // Legend widget setup
+      const haloLayer = new FeatureLayer({
+        url: uapLayer.url,
+        renderer: haloRenderer,
+        outFields: [],
+        popupEnabled: false,
+        visible: true
+      });
+
+      map.addMany([haloLayer, uapLayer]);
+
+      // SEARCH BAR
+      view.ui.add(new Search({ view }), "bottom-right");
+
+      /*
+       * instead of adding the remaining widgets to 'view', just call the classes (IE: new Expand(), 
+       * Zoom() etc), and place the objects manually in containers
+       */
+
+      // INFO BUTTON CONTENT
+      const infoContent = document.createElement("div");
+      infoContent.innerHTML = `
+        <h3>UAP Sightings Map</h3>
+        <p>Use the "Report Sighting" button to report UAP event. </br>Sightings are displayed on the map, click the 🛸 icons for info.</p>
+      `;
+      // INFO BUTTON
+      const infoExpand = new Expand({
+        view,
+        content: infoContent,
+        expandIconClass: "esri-icon-notice-round",
+        expandTooltip: "Map Info",
+        container: "infoControl",   // <-- put all the 'expand' buttons in their divs (info, legend, and basemap)
+        group: "controls"   // <-- assign a group name to all the expand buttons, this way, only 1 menu from the group can be open 
+      });
+
+      // ZOOM
+      const zoom = new Zoom({
+        view,
+        container: "zoomControl"
+      });
+
+      // LOCATE 
+      const locate = new Locate({
+        view,
+        container: "locateControl"
+      });
+
+      // LEGEND 
       const legend = new Legend({
-        view: view,
+        view,
         layerInfos: [{
           layer: uapLayer,
           title: "UAP Reporting"
         }]
       });
-
       const legendExpand = new Expand({
-        view: view,
+        view,
         content: legend,
         expanded: false,
-        expandTooltip: "Legend"
+        expandTooltip: "Legend",
+        container: "legendControl",
+        group: "controls"
+      });
+      // auto-collapse on xsmall screens
+      view.watch("widthBreakpoint", bp => {
+        legendExpand.expanded = (bp !== "xsmall");
       });
 
-      // Auto-collapse legend on small screens
-      view.watch("widthBreakpoint", (breakpoint) => {
-        legendExpand.expanded = (breakpoint !== "xsmall");
-      });
-
-      view.ui.add(legendExpand, "bottom-left");
-
-      // Basemap gallery to switch styles (dark, satellite, etc.)
-      const basemapGallery = new BasemapGallery({ view: view });
+      // BASEMAP GALLERY 
+      const basemapGallery = new BasemapGallery({ view });
       const galleryExpand = new Expand({
-        view: view,
+        view,
         content: basemapGallery,
-        expandTooltip: "Basemap Gallery"
+        expandTooltip: "Basemap Gallery",
+        container: "basemapControl",
+        group: "controls"
       });
-      view.ui.add(galleryExpand, "top-left");
+
+
     });
   </script>
 </body>
+
 </html>

--- a/widget-styles.css
+++ b/widget-styles.css
@@ -1,0 +1,241 @@
+:root {
+    --bg-primary: #934BF3;
+    --bg-hover: #cfec5c;
+    --accent: #00ff40;
+    --panel-bg: #111;
+    --panel-text: #00ff40;
+    --icon-text: #0d1b2a;
+    --radius: 6px;
+    --transition: 0.3s ease;
+    --menu-offset: 15px;
+    --menu-minw: 200px;
+    --menu-maxh: 70vh;
+}
+
+/* Pill button styles */
+.esri-widget--button[title],
+.esri-widget--button.esri-search__submit-button[title="Search"],
+.esri-widget--button.esri-locate,
+.esri-widget--button.esri-search__submit-button,
+.esri-widget--button[aria-controls$="_content"] {
+    background: var(--bg-primary) !important;
+    border-radius: var(--radius) !important;
+    transition: background var(--transition), box-shadow var(--transition) !important;
+}
+
+/* Hover for all of the above */
+.esri-widget--button[title]:hover,
+.esri-widget--button.esri-locate:hover,
+.esri-widget--button.esri-search__submit-button:hover,
+.esri-widget--button[aria-controls$="_content"]:hover {
+    background: var(--bg-hover) !important;
+    box-shadow: 0 0 15px var(--accent), 0 0 30px var(--accent) !important;
+}
+
+/* Icon color inside controls */
+#controls .esri-widget--button .esri-icon,
+.esri-widget--button[aria-controls$="_content"] .esri-icon,
+.esri-widget--button[aria-controls$="_content"] .esri-collapse__icon,
+.esri-widget--button[aria-controls$="_content"] .esri-expand__icon,
+.esri-input.esri-search__input::placeholder,
+.esri-search__container .esri-widget--button .esri-icon {
+    color: var(--icon-text) !important;
+    opacity: 1 !important;
+}
+
+/* Common sizing & centering for all expand toggles */
+.esri-widget--button[aria-controls$="_content"] {
+    width: 28px !important;
+    height: 28px !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+}
+
+/* The wrappers for legend, basemap, info */
+#legendControl.esri-expand,
+#basemapControl.esri-expand,
+#infoControl.esri-expand {
+    position: relative !important;
+    overflow: visible !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    margin: 6px 0 !important;
+    background-color: var(--bg-primary) !important;
+    border-radius: var(--radius) !important;
+    color: var(--icon-text) !important;
+}
+
+/* Hover glow for the expand panels */
+#legendControl.esri-expand:hover,
+#basemapControl.esri-expand:hover,
+#infoControl.esri-expand:hover {
+    box-shadow: 0 0 15px var(--accent), 0 0 30px var(--accent) !important;
+}
+
+/* Expand panels */
+#legendControl .esri-expand__content,
+#basemapControl .esri-expand__content,
+#infoControl .esri-expand__content {
+    position: absolute !important;
+    top: 0 !important;
+    left: 100% !important;
+    margin-left: var(--menu-offset) !important;
+    z-index: 9999 !important;
+    min-width: var(--menu-minw);
+    max-height: var(--menu-maxh) !important;
+    overflow-y: auto !important;
+    background-color: var(--panel-bg) !important;
+    color: var(--panel-text) !important;
+    border-radius: var(--radius) !important;
+    padding: 8px !important;
+    box-shadow: 0 0 15px var(--accent), 0 0 30px var(--accent) !important;
+}
+
+/* panels within panels... */
+#legendControl .esri-expand__content .esri-legend,
+#basemapControl .esri-expand__content .esri-basemap-gallery,
+#infoControl .esri-expand__content .esri-widget--panel,
+#legendControl .esri-expand__content h3.esri-legend__service-label {
+    background-color: var(--panel-bg) !important;
+    color: var(--panel-text) !important;
+}
+
+/* Hide container corners for default search stuff */
+.esri-search__container,
+.esri-component.esri-search {
+    background: transparent !important;
+    border-radius: var(--radius) !important;
+    overflow: hidden !important;
+    opacity: 1 !important;
+}
+
+/* Style the search bar*/
+.esri-search__container .esri-input.esri-search__input,
+.esri-search__container .esri-widget--button.esri-search__submit-button,
+.esri-search__container .esri-widget--button.esri-search__reset-button {
+    border: 2.5px solid var(--accent) !important;
+    transition: background var(--transition), box-shadow var(--transition) !important;
+    color: var(--icon-text) !important;
+    opacity: 1;
+    box-shadow: 0 0 15px var(--accent), 0 0 30px var(--accent) !important;
+}
+
+/* input pill gets left round only */
+.esri-search__container .esri-input.esri-search__input {
+    border-radius: var(--radius) 0 0 var(--radius) !important;
+}
+
+/* submit and reset buttons get right-round only; no left border */
+.esri-search__container .esri-widget--button.esri-search__submit-button,
+.esri-search__container .esri-widget--button.esri-search__reset-button {
+    border-radius: 0 var(--radius) var(--radius) 0 !important;
+    border-left: none !important;
+}
+
+/* Search-input and suggestions share these */
+.esri-input.esri-search__input[title="Find address or place"] {
+    background: var(--bg-primary) !important;
+    color: var(--icon-text) !important;
+    border: 2.5px solid var(--accent) !important;
+    border-radius: var(--radius) 0 0 var(--radius) !important;
+    transition: background var(--transition), box-shadow var(--transition);
+}
+
+.esri-input.esri-search__input:hover,
+.esri-input.esri-search__input:focus {
+    background: var(--bg-hover) !important;
+    outline: none !important;
+}
+
+.esri-search__suggestions-menu {
+    border-radius: 0 0 var(--radius) var(--radius) !important;
+}
+
+/*
+ * CONTROL CONTAINER-
+ * stacks all controls vertically in a pill
+ */
+#controls {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    top: 10px;
+    left: 10px;
+    background-color: #934BF3;
+    border-radius: 16px;
+    padding: 3px;
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+    z-index: 10;
+    min-height: 200px;
+    opacity: 0.85;
+    border: 2.5px solid #00ff40 !important;
+}
+
+#controls>* {
+    margin: 6px 0;
+}
+
+/*
+ * ZOOM BUTTONS  
+ */
+#zoomControl.esri-zoom {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 4px;
+    background-color: #934BF3 !important;
+    border-radius: 6px !important;
+    transition: background-color 0.3s ease;
+}
+
+/* 86 the wrapper’s hover so it doesnt turn yellow */
+#zoomControl.esri-zoom:hover {
+    background-color: #934BF3 !important;
+}
+
+/* Make each inner button transparent by default */
+#zoomControl .esri-widget--button {
+    background-color: transparent !important;
+    border-radius: 6px !important;
+    transition: background-color 0.3s ease;
+}
+
+#zoomControl .esri-widget--button:hover {
+    background-color: #cfec5c !important;
+    box-shadow: 0 0 15px #00ff40, 0 0 30px #00ff40;
+}
+
+/* target the Esri popup close “X” */
+.esri-popup__icon.esri-icon-close,
+.esri-popup__icon--dock-icon.esri-icon-dock-right.esri-popup__icon,
+.esri-popup__button.esri-popup__action[title="Zoom to"] .esri-popup__icon.esri-icon-zoom-in-magnifying-glass,
+.esri-popup__action-text {
+    color: var(--accent) !important;
+    opacity: 1 !important;
+}
+
+/* pop up button hover styles*/
+.esri-popup__button[aria-label="Close"]:hover,
+.esri-popup__button[title="Dock"]:hover,
+.esri-popup__header-container--button[title="Collapse"]:hover {
+    background-color: var(--bg-hover) !important;
+    border-radius: 50% !important;
+    transition: background-color var(--transition) !important;
+    color: var(--icon-text);
+}
+
+/* Popup header title turns dark on hover of the header bar */
+.esri-popup__header-container--button:hover .esri-popup__header-title,
+.esri-popup__button[title="Dock"]:hover .esri-popup__icon--dock-icon.esri-icon-dock-right,
+.esri-popup__button[aria-label="Close"]:hover .esri-popup__icon.esri-icon-close {
+    color: var(--icon-text) !important;
+    opacity: 1 !important;
+    transition: color var(--transition) !important;
+}
+
+.esri-popup .esri-feature__content-element {
+    background-color: var(--bg-hover) !important;
+    border-radius: var(--radius) !important;
+    padding: 8px !important;
+}

--- a/widget-styles.css
+++ b/widget-styles.css
@@ -206,7 +206,7 @@
     box-shadow: 0 0 15px #00ff40, 0 0 30px #00ff40;
 }
 
-/* target the Esri popup close “X” */
+/* target the Esri popup close, collapse, and dock buttons */
 .esri-popup__icon.esri-icon-close,
 .esri-popup__icon--dock-icon.esri-icon-dock-right.esri-popup__icon,
 .esri-popup__button.esri-popup__action[title="Zoom to"] .esri-popup__icon.esri-icon-zoom-in-magnifying-glass,
@@ -225,7 +225,7 @@
     color: var(--icon-text);
 }
 
-/* Popup header title turns dark on hover of the header bar */
+/* Change the icon colors on hover */
 .esri-popup__header-container--button:hover .esri-popup__header-title,
 .esri-popup__button[title="Dock"]:hover .esri-popup__icon--dock-icon.esri-icon-dock-right,
 .esri-popup__button[aria-label="Close"]:hover .esri-popup__icon.esri-icon-close {


### PR DESCRIPTION
This is mostly me  learning how to target different esri objects with css. The pop ups can also be styled using the CustomContent class, but that comes with it's own headaches and still results in like 300-500 lines of css...

<img width="1912" height="870" alt="image" src="https://github.com/user-attachments/assets/bb2b9b9f-eed8-4358-a3eb-4dae3c81a43f" />

Style changes:
- Pop up buttons
- Expand menus
- Widgets and search bar
- Made the icons a little bigger and put a circle behind them. More of a "could I do it" than a "should I do it". My intent was to make a transparent circle behind the icons and apply the green glow with css, also wanted to dim the capital city labels a bit, but both seemingly simple tasks would require making a clone of the esri raster basemap and make a vector. 